### PR TITLE
declare missing key usage required by Google Chrome (when using TLS 1.3, no pb with TLS 1.2)

### DIFF
--- a/sslfie
+++ b/sslfie
@@ -212,7 +212,7 @@ $OU_LINE
 CN = $CN
 
 [v3_req]
-keyUsage = keyEncipherment, dataEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = $SUBJECT_ALT_NAME
 "


### PR DESCRIPTION
see #4 

http://rcardon.free.fr/websign/download/api-x509-ext/be/cardon/asn1/x509/extensions/KeyUsage.html

